### PR TITLE
:loud_sound: Adding some logs to give feedback on install command

### DIFF
--- a/app/install
+++ b/app/install
@@ -30,7 +30,12 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 ln -snf "$APP_DIR/cli" "$FOLDER/$NAME"
-
+if [[ $? == 0 ]]; then
+    info "Succesfully installed repos in your folder $FOLDER"
+else
+    error "Failed to install repos in folder $FOLDER"
+    exit 1
+fi
 cat > "$BASH_COMPLETION/$NAME" <<EOC
 source "$APP_DIR/complete"
 complete -F _bash_cli $NAME


### PR DESCRIPTION
When the install command is successfull we don't have any feedback on the results.

I simply added some feedback on successfull while linking the file